### PR TITLE
Minor fixes on typos, markdown link, etc

### DIFF
--- a/1-century-dcip-inversion.ipynb
+++ b/1-century-dcip-inversion.ipynb
@@ -693,7 +693,8 @@
     "   - typically add ~the maximum source-receiver separation in each dimension\n",
     "   \n",
     "\n",
-    "Here, we will use a `TensorMesh` which is described by ???\n",
+    "Here, we will use a `TensorMesh`, where each dimension can be defined with just a cell width. \n",
+    "A tensor in each dimension is enough to define the entire mesh.\n",
     "For larger domains, we recommend using an `TreeMesh`. There are [examples in the discretize documentation](http://discretize.simpeg.xyz/en/master/tutorials/mesh_generation/4_tree_mesh.html) for creating QuadTree (2D) and OcTree (3D) meshes. "
    ]
   },

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Transform 2020: Geophysical inversions with SimPEG
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/simpeg/transform-2020-simpeg/master) 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/simpeg/transform-2020-simpeg/master)
 [![Build Status](https://travis-ci.org/simpeg/transform-2020-simpeg.svg?branch=master)](https://travis-ci.org/simpeg/transform-2020-simpeg)
 [![License](https://img.shields.io/github/license/simpeg/transform-2020-simpeg.svg)](https://github.com/simpeg/transform-2020-simpeg/blob/master/LICENSE)
 
@@ -24,13 +24,13 @@
 - [Doug Oldenburg](http://github.com/dougoldenburg)
 - and the [SimPEG contributors](https://github.com/simpeg/simpeg/graphs/contributors)
 
-## Before the tutorial 
+## Before the tutorial
 
 Make sure you've done these things before the tutorial on Tuesday:
 
 1. Sign-up for the [Software Underground Slack](https://softwareunderground.org/slack)
 1. Join the channel `t20-tue-simpeg`. This is where **all communication will happen**.
-1. Set up your computer ([intructions below](#setup)). We will not have time to
+1. Set up your computer ([instructions below](#usage)). We will not have time to
    solve many computer issues during the tutorial so make sure you do this
    ahead of time. If you need any help, ask at the `t20-tue-simpeg` channel on
    Slack.
@@ -40,7 +40,7 @@ Make sure you've done these things before the tutorial on Tuesday:
 
 ## Summary
 
-This repo contains the notebooks and tutorial resources for the Transform 2020 tutorial on Simulations and inversions with SimPEG. 
+This repo contains the notebooks and tutorial resources for the Transform 2020 tutorial on Simulations and inversions with SimPEG.
 
 - [Session Description](https://transform2020.sched.com/event/cD5V/tutorial-geophysical-inversion-in-simpeg)
 - [Intro Slides](https://docs.google.com/presentation/d/1Iw0chJUvjaiuGpQIqiYal719pcvWD2xs2z2aXkpQThQ/edit?usp=sharing)
@@ -48,15 +48,15 @@ This repo contains the notebooks and tutorial resources for the Transform 2020 t
 In this tutorial, we will provide a hand-on overview of using SimPEG to simulate and invert geophysical data. The examples we plan to work through use Direct Current (DC) Resistivity and Induced Polarization (IP) data from the Century Zinc Deposit in Australia.
 
 Starting from field data in a text file we will learn how to
-- load those data into SimPEG 
+- load those data into SimPEG
 - construct a survey object that contains the geometry of the sources and receivers
-- set up and run a forward simulation 
+- set up and run a forward simulation
 - define the inverse problem consisting of a data misfit and regularization
 - run an inversion and discuss inversion strategies
 
 Then, we will work with a synthetic example to
 - demonstrate how to explore aspects of the physics with SimPEG
-- explore the role and influence of parameters used in an inversion 
+- explore the role and influence of parameters used in an inversion
 
 ## Prerequisites
 
@@ -67,29 +67,29 @@ Then, we will work with a synthetic example to
   [more python for subsurface](https://transform2020.sched.com/event/c7Jn/more-python-for-subsurface) tutorials).
 * All coding will be done in Jupyter notebooks. I'll explain how they work
   briefly but it will help if you've used them before.
-* We'll use [numpy](https://numpy.org/), [matplotlib](https://matplotlib.org/), and 
+* We'll use [numpy](https://numpy.org/), [matplotlib](https://matplotlib.org/), and
   [ipywidgets](https://ipywidgets.readthedocs.io/)
   You don't need to be an expert in these tools but some familiarity will help.
-  
+
 **Geophysical Inversions**
 
-* This tutorial will focus on Direct Current (DC) Resistivity and Induced Polarization (IP). 
-  I'll explain the basic principles, but if these are new to you, then I would recommend 
+* This tutorial will focus on Direct Current (DC) Resistivity and Induced Polarization (IP).
+  I'll explain the basic principles, but if these are new to you, then I would recommend
   taking a read through the [DC Resistivity](https://gpg.geosci.xyz/content/DC_resistivity/index.html)
   and [Induced Polarization](https://gpg.geosci.xyz/content/induced_polarization/index.html) sections
   of the [Geophysics for Practicing Geoscientists resource](https://gpg.geosci.xyz/index.html)
-* Similarly, I do not assume an extensive background in inversions, but it will help if you have been 
+* Similarly, I do not assume an extensive background in inversions, but it will help if you have been
   introduced to some concepts. The [GIFTools Cookbook](https://giftoolscookbook.readthedocs.io/en/latest/content/fundamentals/index.html)
-  provides a nice overview. 
+  provides a nice overview.
 
-## Usage 
+## Usage
 
 There are a few things you'll need to follow the tutorial:
 
-1. A working Python intallation ([Anaconda](https://www.anaconda.com/products/individual) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html))
+1. A working Python installation ([Anaconda](https://www.anaconda.com/products/individual) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html))
 2. The SimPEG *conda environment* installed
-3. A web browser that works with Jupyter 
-   (basically anything except Internt Explorer)
+3. A web browser that works with Jupyter
+   (basically anything except Internet Explorer)
 
 To get things setup, please do the following.
 
@@ -112,12 +112,12 @@ manager. If you already have one, you can skip this step.
 
 To access the notebooks, there are 3 options (in order of preference):
 1. Use git to clone this repository
-2. From GitHub, you can use the `download` option to download this repository as a zip file (follow all instructions below, replacing the `git clone` step with download and unzip the zip file with the repository contents.  
+2. From GitHub, you can use the `download` option to download this repository as a zip file (follow all instructions below, replacing the `git clone` step with download and unzip the zip file with the repository contents.
 3. You can run the notebooks online with binder through: https://mybinder.org/v2/gh/simpeg/transform-2020-simpeg/master
 
-To clone this repository, open up a terminal and navigate to where you want this repository stored on your computer. 
+To clone this repository, open up a terminal and navigate to where you want this repository stored on your computer.
 
-Then run 
+Then run
 ```
 git clone https://github.com/simpeg/transform-2020-simpeg.git
 ```
@@ -126,13 +126,13 @@ to clone the repository, and `cd` into the `transform-2020-simpeg` directory
 cd transform-2020-simpeg
 ```
 
-### Step 3: Create the SimPEG tutorial conda environment 
+### Step 3: Create the SimPEG tutorial conda environment
 
 From inside of the `transform-2020-simpeg` repository, create the `t20-tue-simpeg` conda environment
 ```
 conda env create -f environment.yml
 ```
-and activate the environment 
+and activate the environment
 ```
 conda activate t20-tue-simpeg
 ```
@@ -146,9 +146,10 @@ jupyter notebook
 Jupyter will then launch in your web-browser.
 
 If you are able to open any one of the notebooks and run the first cell, then you should be good to go!
-If you run into issues, please post in the #t20-tue-simpeg slack channel. 
+If you run into issues, please post in the #t20-tue-simpeg slack channel.
 
 ## Resources
+
 **Resources on Geophysics and Inversions**
 - [Geophysics for Practicing Geoscientists](https://gpg.geosci.xyz/)
 - [EM GeoSci](http://em.geosci.xyz/)
@@ -167,4 +168,3 @@ If you run into issues, please post in the #t20-tue-simpeg slack channel.
 All code and text in this repository is free software: you can redistribute it and/or
 modify it under the terms of the MIT License.
 A copy of this license is provided in [LICENSE](LICENSE).
-


### PR DESCRIPTION
Thanks again for the wonderful simpeg tutorial!

This is a small PR that addresses a few very minor stuff that I came across.

* When I was working through the setup instructions, I came across a few typos and a broken internal link in markdown. 
* My text editor also removed the trailing spaces - hope you don't mind.
* `1-century-dcip-inversion.ipynb`  notebook had some missing description for `TensorMesh`. I filled in the `???` with what @lheagy described in the tutorial.